### PR TITLE
Add rollup config for UMD an ESM modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "webauthn-simple-app",
   "version": "1.2.0",
   "description": "webauthn-simple-app",
-  "main": "webauthn-simple-app.js",
+  "main": "dist/webauthn-simple-app.js",
+  "module": "dist/webauthn-simple-app.esm.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
+    "build": "cross-env NODE_ENV=development rollup -c rollup.config.js",
+    "build:prod": "cross-env NODE_ENV=production rollup -c rollup.config.js",
     "test": "mocha test/common/*.js test/node/*.js && grunt default",
     "docs": "jsdoc -c ./.jsdoc-conf.json",
     "publish-docs": "gh-pages --repo https://$GH_TOKEN@github.com/apowers313/webauthn-simple-app.git --dist docs"
@@ -28,7 +31,10 @@
   },
   "homepage": "https://github.com/apowers313/webauthn-simple-app#readme",
   "devDependencies": {
+    "babel-core": "^6.26.3",
+    "babel-preset-env": "^1.7.0",
     "chai": "^3.5.0",
+    "cross-env": "^5.2.0",
     "docdash": "^0.4.0",
     "fido2-helpers": "^1.4.0",
     "gh-pages": "^0.12.0",
@@ -36,6 +42,8 @@
     "grunt-contrib-connect": "^1.0.2",
     "grunt-saucelabs": "^9.0.0",
     "jsdoc": "^3.5.5",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "rollup": "^0.61.2",
+    "rollup-plugin-babel": "^3.0.5"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,32 @@
+import babel from 'rollup-plugin-babel'
+
+const env = process.env.NODE_ENV;
+
+const babelConf = {
+    exclude: "node_modules/**",
+    babelrc: false,
+    presets:
+        [
+            ['env', {modules: false}]
+        ]
+};
+
+export default {
+    input: 'webauthn-simple-app.js',
+    plugins: [
+        babel(babelConf)
+    ],
+    output: [
+        {
+            file: 'dist/webauthn-simple-app.js',
+            format: 'umd',
+            name: 'WebAuthnSimpleApp',
+            sourcemap: (env === 'development')
+        },
+        {
+            file: 'dist/webauthn-simple-app.esm.js',
+            format: 'es',
+            sourcemap: (env === 'development')
+        },
+    ]
+};

--- a/test/browser/test.html
+++ b/test/browser/test.html
@@ -15,7 +15,7 @@
     <script src="js/chai.js" type="text/javascript"></script>
     <script src="js/sinon-1.17.1.js"></script>
     <!-- Insert test scripts here -->
-    <script src="../../webauthn-simple-app.js"></script>
+    <script src="../../dist/webauthn-simple-app.js"></script>
     <script src="../../node_modules/fido2-helpers/fido2-helpers.js"></script>
     <script src="../common/test.js"></script>
     <script src="test.js"></script>

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -121,11 +121,11 @@ describe("WebAuthnApp", () => {
 
     var app;
     beforeEach(() => {
-        app = new window.WebAuthnApp();
+        app = new window.WebAuthnSimpleApp.WebAuthnApp();
     });
 
     it("exists", () => {
-        assert.isFunction(window.WebAuthnApp);
+        assert.isFunction(window.WebAuthnSimpleApp.WebAuthnApp);
     });
 
     it("is constructor", () => {

--- a/test/common/test.js
+++ b/test/common/test.js
@@ -9,41 +9,33 @@
 
 "use strict";
 
+var waApp;
 if (typeof module === "object" && module.exports) {
     // node.js setup
     global.assert = require("chai").assert; // eslint-disable-line global-require
     global.fido2Helpers = require("fido2-helpers"); // eslint-disable-line global-require
-    const {
-        WebAuthnHelpers,
-        Msg,
-        ServerResponse,
-        CreateOptionsRequest,
-        CreateOptions,
-        CredentialAttestation,
-        GetOptionsRequest,
-        GetOptions,
-        CredentialAssertion,
-        WebAuthnOptions
-    } = require("../../webauthn-simple-app"); // eslint-disable-line global-require
-    global.WebAuthnHelpers = WebAuthnHelpers;
-    global.Msg = Msg;
-    global.ServerResponse = ServerResponse;
-    global.CreateOptionsRequest = CreateOptionsRequest;
-    global.CreateOptions = CreateOptions;
-    global.CredentialAttestation = CredentialAttestation;
-    global.GetOptionsRequest = GetOptionsRequest;
-    global.GetOptions = GetOptions;
-    global.CreateOptionsRequest = CreateOptionsRequest;
-    global.CredentialAssertion = CredentialAssertion;
-    global.WebAuthnOptions = WebAuthnOptions;
+    waApp = require("../../dist/webauthn-simple-app"); // eslint-disable-line global-require
 } else {
     // browser setup
     window.assert = chai.assert;
+    waApp = window.WebAuthnSimpleApp;
     mocha.setup("bdd");
 }
 
+var WebAuthnHelpers = waApp.WebAuthnHelpers;
+var Msg = waApp.Msg;
+var ServerResponse = waApp.ServerResponse;
+var CreateOptionsRequest = waApp.CreateOptionsRequest;
+var CreateOptions = waApp.CreateOptions;
+var CredentialAttestation = waApp.CredentialAttestation;
+var GetOptionsRequest = waApp.GetOptionsRequest;
+var GetOptions = waApp.GetOptions;
+var CreateOptionsRequest = waApp.CreateOptionsRequest;
+var CredentialAssertion = waApp.CredentialAssertion;
+var WebAuthnOptions = waApp.WebAuthnOptions;
+
 describe("defaultRoutes", function() {
-    var defaultRoutes = WebAuthnHelpers.defaultRoutes;
+    var defaultRoutes = waApp.WebAuthnHelpers.defaultRoutes;
     it("is object", function() {
         assert.isObject(defaultRoutes);
     });

--- a/test/node/test.js
+++ b/test/node/test.js
@@ -11,7 +11,7 @@ const {
     GetOptions,
     CredentialAssertion,
     WebAuthnOptions
-} = require("../../webauthn-simple-app");
+} = require("../../dist/webauthn-simple-app");
 
 describe("WebAuthnApp", function() {
     it("is running on node", function() {

--- a/webauthn-simple-app.js
+++ b/webauthn-simple-app.js
@@ -20,7 +20,7 @@
 // 1b. client <<< GetOptions <<< server
 // 2a. client >>> CredentialAssertion >>> server
 // 2b. client <<< ServerResponse <<< server
-(function() {
+
     /**
      * Virtual class for messages that serves as the base
      * for all other messages.
@@ -1554,7 +1554,7 @@
 
     // exports, regardless of whether we're in browser or node.js
     // note that browser is using global namespace (i.e. - "window");
-    exp.WebAuthnHelpers = {
+    export let WebAuthnHelpers = {
         defaultRoutes: {
             attestationOptions: "/attestation/options",
             attestationResult: "/attestation/result",
@@ -1567,14 +1567,16 @@
             isBrowser
         }
     };
-    exp.Msg = Msg;
-    exp.ServerResponse = ServerResponse;
-    exp.CreateOptionsRequest = CreateOptionsRequest;
-    exp.CreateOptions = CreateOptions;
-    exp.CredentialAttestation = CredentialAttestation;
-    exp.GetOptionsRequest = GetOptionsRequest;
-    exp.GetOptions = GetOptions;
-    exp.CredentialAssertion = CredentialAssertion;
-    exp.WebAuthnOptions = WebAuthnOptions;
-    exp.WebAuthnApp = WebAuthnApp;
-}());
+    export {
+        Msg,
+        ServerResponse,
+        CreateOptionsRequest,
+        CreateOptions,
+        CredentialAttestation,
+        GetOptionsRequest,
+        GetOptions,
+        CredentialAssertion,
+        WebAuthnOptions,
+        WebAuthnApp
+    };
+


### PR DESCRIPTION
Here is my PR for issue #5. I have modified the main JS file to use ES6 exports and removed the wrapping function (note that the code should be indented to the left 1 tab but I kept the indentation to keep the PR cleaner). With a modern browser you could directly use this file as a JS module. However it is good practice to generate an distribution ES module file with exports but with all other features transpiled to a specific target. This is the `dist/webauth-simple-app.esm.js` file. It is ES5 compatible apart from the exports. This is done by the babel plugin (babel-preset-env as preset). 
For CommonJS/AMD or <script> tag use a UMD module is built to `dist/webauthn-simple-app.js`.

You can use `npm run build` or `npm run build:prod` to build these distribution files (currently the only difference is the generation of source maps).

One problem I came across were the tests. On the node side, commonJS modules are expected so it no longer works with the new export statements. I have solved this by referring to the dist file instead. Downside is that you need to run build before test. If you want to keep using the actual source file in tests then alternative are using ES6 import statements in the tests as well or using `mocha --require babel-core/register` which will magically make it work (it will transpile the modules on the fly). However for the shared test code and the actual browser tests the former will only work with ES6 browsers and the latter can not work in a browser environment.

On the browser side I also modified the code to use the dist file instead. Another change that had to be made in the shared test code on the browser side is that all exports are now grouped in one single global object, `window.WebAuthnSimpleApp` (btw, this name is pretty long but you can change it to something else in the rollup config if you want). This is a breaking change but it is more similar to how commonJS works and prevents global namespace pollution.